### PR TITLE
Add local state to avoid multiple rerenders while modifying note

### DIFF
--- a/src/components/Note/Note.jsx
+++ b/src/components/Note/Note.jsx
@@ -4,29 +4,37 @@ import "./Note.css";
 
 function Note({ content, deleteNote, modifyNote }) {
   const [isEditing, setIsEditing] = useState(false);
+  const [localNoteContent, setLocalNoteContent] = useState(content);
+  
   const handleEdit = () => {
     setIsEditing(true);
   };
+
   const handleSave = () => {
     setIsEditing(false);
+    modifyNote(localNoteContent);
   };
+
   const handleDelete = () => {
     deleteNote();
   };
+
   const handleModification = (event) => {
-    modifyNote(event.target.value);
+    setLocalNoteContent(event.target.value);
   };
+
   return (
     <div className="note-card">
       {isEditing ? (
         <textarea
           className="note-content"
-          value={content}
+          value={localNoteContent}
           onChange={handleModification}
         />
       ) : (
         <div className="note-content">{content}</div>
       )}
+
       {isEditing ? (
         <div className="note-actions">
           <button onClick={handleSave}>Save</button>
@@ -41,6 +49,7 @@ function Note({ content, deleteNote, modifyNote }) {
     </div>
   );
 }
+
 Note.propTypes = {
   content: PropTypes.string,
   deleteNote: PropTypes.func,


### PR DESCRIPTION
This commit adds local state to the note editor component, preventing multiple rerenders when modifying a note. Instead of directly modifying the main parent state, a local state is used, ensuring that only a single rerender occurs during the save operation.