### PR TITLE
Reduce font size of metadata in note

### DIFF
--- a/src/components/Note/Note.css
+++ b/src/components/Note/Note.css
@@ -15,6 +15,7 @@
     margin: 0.2rem;
     padding: 0.2rem;
     font: inherit;
+    font-size: 0.6rem;
     text-align: center;
   }
   .note-actions {


### PR DESCRIPTION
This commit reduces the font size of the metadata, including the created time and last modified, in the note feature. By decreasing the font size, the metadata becomes less prominent, creating a more visually balanced and aesthetically pleasing display. This change enhances the overall user experience by improving readability and ensuring that the main content of the note remains the focal point.